### PR TITLE
Add OpenStreetMap dispensary search

### DIFF
--- a/ShowMoBud/Components/DispensaryMapBase.cs
+++ b/ShowMoBud/Components/DispensaryMapBase.cs
@@ -49,10 +49,8 @@ namespace ShowMoBud.Components
             // Center the map on the user's location
             await JS.InvokeVoidAsync("smbMap.setView", _userLat, _userLng, 12);
 
-            // Get all dispensaries and filter by those within the search radius
-            var all = Dispensaries.GetAll();
-            var hits = all.Where(d => HaversineMiles(_userLat, _userLng, d.Latitude, d.Longitude) <= _radiusMiles)
-                          .ToList();
+            // Fetch nearby dispensaries from the API
+            var hits = await Dispensaries.GetNearbyAsync(_userLat, _userLng, _radiusMiles);
 
             // Clear any existing markers from the map
             await JS.InvokeVoidAsync("smbMap.clearMarkers");
@@ -67,23 +65,6 @@ namespace ShowMoBud.Components
                 await JS.InvokeVoidAsync("smbMap.addMarker", d.Latitude, d.Longitude, popup);
             }
         }
-
-        // Calculates the distance in miles between two latitude/longitude points using the Haversine formula
-        private static double HaversineMiles(double lat1, double lon1, double lat2, double lon2)
-        {
-            const double R = 3958.7613; // Earth radius in miles
-            double dLat = ToRad(lat2 - lat1);
-            double dLon = ToRad(lon2 - lon1);
-            lat1 = ToRad(lat1); lat2 = ToRad(lat2);
-            double a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
-                       Math.Sin(dLon / 2) * Math.Sin(dLon / 2) * Math.Cos(lat1) * Math.Cos(lat2);
-            double c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
-            return R * c;
-        }
-
-        // Converts degrees to radians
-        private static double ToRad(double deg) => deg * Math.PI / 180.0;
-
         // Record type for deserializing geolocation results from JS interop
         private record GeoPosition(GeoCoords coords);
         private record GeoCoords(double latitude, double longitude);

--- a/ShowMoBud/Services/DispensaryService.cs
+++ b/ShowMoBud/Services/DispensaryService.cs
@@ -1,19 +1,21 @@
-﻿using ShowMoBud.Models;
+using System.Net.Http.Json;
+using ShowMoBud.Models;
 
-namespace ShowMoBud.Services
+namespace ShowMoBud.Services;
+
+public class DispensaryService
 {
-    public class DispensaryService
+    private readonly HttpClient _http;
+
+    public DispensaryService(HttpClient http)
     {
+        _http = http;
+    }
 
-        private static readonly List<Dispensary> _all = new()
-        {
-
-            new() {Name = "Heya Wellness", Address = "4300 N Service Rd, St. Peters, MO 63376", Latitude = 38.798870, Longitude = -90.583379},
-            new() {Name = "Root 66", Address = "3004 S St Peters Pkwy, St. Peters, MO 63303", Latitude = 38.772820, Longitude = -90.629570},
-            new() {Name = "Kind Goods", Address = "3899 Veterans Memorial,, Ste J, St Peters, MO 63376", Longitude = -90.576820, Latitude = 38.799030},
-            new() {Name = "Mint Cannabis", Address = "150 Mid Rivers Mall Cir, St. Peters, MO 63376", Longitude = -90.576820, Latitude = 38.799030}
-        };
-
-        public IReadOnlyList<Dispensary> GetAll() => _all;
+    public async Task<IReadOnlyList<Dispensary>> GetNearbyAsync(double lat, double lng, double radiusMiles)
+    {
+        var url = $"api/dispensaries/nearby/osm?lat={lat}&lng={lng}&radiusMiles={radiusMiles}";
+        return await _http.GetFromJsonAsync<List<Dispensary>>(url) ?? new List<Dispensary>();
     }
 }
+

--- a/ShowMoBudAPI.Tests/Services/AuthenticationServiceTests.cs
+++ b/ShowMoBudAPI.Tests/Services/AuthenticationServiceTests.cs
@@ -21,7 +21,7 @@ namespace ShowMoBudAPI.Tests.Services
         public AuthenticationServiceTests()
         {
 
-            _mockDbContext = new Mock<ShowMoBudContext>();
+            _mockDbContext = new Mock<ShowMoBudContext>(new DbContextOptions<ShowMoBudContext>());
             _mockEncryptionService = new Mock<IEncryptionService>();
             _mockJwtService = new Mock<IJwtService>();
 
@@ -34,7 +34,7 @@ namespace ShowMoBudAPI.Tests.Services
                 .Returns(new byte[64]);
 
             _mockJwtService
-                .Setup(js => js.GenerateToken(It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(js => js.GenerateToken(It.IsAny<string>(), It.IsAny<Role>()))
                 .Returns(new JwtResponse
                 {
                     Token = "mocked_token",

--- a/ShowMoBudAPI/Controllers/DispensariesController.cs
+++ b/ShowMoBudAPI/Controllers/DispensariesController.cs
@@ -1,0 +1,42 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using ShowMoBudAPI.Models;
+
+namespace ShowMoBudAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DispensariesController : ControllerBase
+{
+    private readonly IHttpClientFactory _clientFactory;
+
+    public DispensariesController(IHttpClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    [HttpGet("nearby/osm")]
+    public async Task<IEnumerable<Dispensary>> GetNearbyOsm(double lat, double lng, double radiusMiles = 10)
+    {
+        var radiusMeters = radiusMiles * 1609.34;
+        var query = $@"[out:json];node[""shop""=""cannabis""](around:{radiusMeters},{lat},{lng});out;";
+
+        var client = _clientFactory.CreateClient();
+        using var content = new StringContent(query, Encoding.UTF8, "text/plain");
+        using var response = await client.PostAsync("https://overpass-api.de/api/interpreter", content);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var elements = doc.RootElement.GetProperty("elements").EnumerateArray();
+
+        return elements.Select(e => new Dispensary
+        {
+            Name = e.TryGetProperty("tags", out var tags) && tags.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed",
+            Latitude = e.GetProperty("lat").GetDouble(),
+            Longitude = e.GetProperty("lon").GetDouble(),
+            Address = e.TryGetProperty("tags", out var t) && t.TryGetProperty("addr:street", out var street) ? street.GetString() : null
+        }).ToList();
+    }
+}
+

--- a/ShowMoBudAPI/Models/Dispensary.cs
+++ b/ShowMoBudAPI/Models/Dispensary.cs
@@ -1,0 +1,10 @@
+namespace ShowMoBudAPI.Models;
+
+public class Dispensary
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Address { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+}
+

--- a/ShowMoBudAPI/Program.cs
+++ b/ShowMoBudAPI/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddSwaggerGen();
 
 //custom services:
 builder.Services.AddScoped<INewsletterService, NewsletterService>();
+builder.Services.AddHttpClient();
 
 //adding service for JWT authentication and authorization
 builder.Services.AddScoped<IJwtService, JwtService>();


### PR DESCRIPTION
## Summary
- query OpenStreetMap Overpass API for cannabis dispensaries via new backend endpoint
- replace hardcoded dispensary list with API-driven search on the front end
- register HttpClient and adjust tests for updated service contracts

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b6b85ff98833089cc705d75a7f21c