### PR TITLE
Redirect Dispensaries to dedicated page

### DIFF
--- a/ShowMoBud/Layout/MainLayout.razor
+++ b/ShowMoBud/Layout/MainLayout.razor
@@ -10,17 +10,11 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 
-<Navbar OnOpenRegister="OpenRegister"
-        OnOpenMap="OpenMap"/>
+<Navbar OnOpenRegister="OpenRegister" />
 
 <div style="height:64px"></div>
 
 @Body
-
-@if (showMap)
-{
-    <Pages.Map.MapOverlay OnClose="CloseMap" />
-}
 
 @if (showRegister)
 {
@@ -30,7 +24,6 @@
 }
 
 @code {
-    private bool showMap = false;
     private bool showRegister = false;
     public async Task OpenRegister()
     {
@@ -40,17 +33,6 @@
     public async Task CloseRegister()
     {
         showRegister = false;
-        await InvokeAsync(StateHasChanged);
-    }
-
-    public async Task OpenMap()
-    {
-        showMap = true;
-        await InvokeAsync(StateHasChanged);
-    }
-    public async Task CloseMap()
-    {
-        showMap = false;
         await InvokeAsync(StateHasChanged);
     }
 }

--- a/ShowMoBud/Pages/Dispensary.razor
+++ b/ShowMoBud/Pages/Dispensary.razor
@@ -1,0 +1,5 @@
+@page "/dispensary"
+@using ShowMoBud.Components
+
+<DispensaryMap />
+

--- a/ShowMoBud/Pages/Shared/Navbar.razor
+++ b/ShowMoBud/Pages/Shared/Navbar.razor
@@ -18,7 +18,7 @@
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Href="/information">Information</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit">Community</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Href="/events">Events &amp; St Louis Area</MudButton>
-        <MudButton Variant="Variant.Text" Color="Color.Inherit" OnClick="TriggerMap">Dispensaries</MudButton>
+        <MudButton Variant="Variant.Text" Color="Color.Inherit" Href="/dispensary">Dispensaries</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Href="/vision">Vision</MudButton>
         <MudButton Variant="Variant.Text" Color="Color.Inherit" Href="/roadmap">Road Map</MudButton>
 
@@ -56,7 +56,7 @@
         <MudNavLink Href="/information" Match="NavLinkMatch.Prefix" @onclick="CloseMenu">Information</MudNavLink>
         <MudNavLink Href="/survey" Match="NavLinkMatch.Prefix">Community</MudNavLink>
         <MudNavLink Href="/events" Match="NavLinkMatch.Prefix" @onclick="CloseMenu">Events &amp; St Louis Area</MudNavLink>
-        <MudNavLink Match="NavLinkMatch.Prefix" @onclick="TriggerMap">Dispensaries</MudNavLink>
+        <MudNavLink Href="/dispensary" Match="NavLinkMatch.Prefix" @onclick="CloseMenu">Dispensaries</MudNavLink>
         <MudNavLink Href="/vision" Match="NavLinkMatch.Prefix" @onclick="CloseMenu">Vision</MudNavLink>
         <MudNavLink Href="/roadmap" Match="NavLinkMatch.Prefix" @onclick="CloseMenu">Road Map</MudNavLink>
         <MudDivider Class="my-2" />

--- a/ShowMoBud/Pages/Shared/NavbarBase.cs
+++ b/ShowMoBud/Pages/Shared/NavbarBase.cs
@@ -7,7 +7,6 @@ namespace ShowMoBud.Pages.Shared
 
         protected bool _mobileMenuOpen { get; set; }
 
-        [Parameter] public EventCallback OnOpenMap { get; set; }
         [Parameter] public EventCallback OnOpenRegister { get; set; }
 
         protected void OpenMenu() => _mobileMenuOpen = true;
@@ -29,13 +28,5 @@ namespace ShowMoBud.Pages.Shared
             }
         }
 
-        protected async Task TriggerMap()
-        {
-            if (_mobileMenuOpen)
-                _mobileMenuOpen = false;
-
-            if (OnOpenMap.HasDelegate)
-                await OnOpenMap.InvokeAsync();
-        }
     }
 }


### PR DESCRIPTION
## Summary
- replace map overlay navigation with link to new `/dispensary` page
- drop map overlay callbacks from navbar and layout
- add `/dispensary` page hosting `DispensaryMap`

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f70dbbcb8833087b5a9fadce571ec